### PR TITLE
feat: update to use A11Y Light theme

### DIFF
--- a/resources/js/clipboard.js
+++ b/resources/js/clipboard.js
@@ -7,7 +7,7 @@ const clipboardIcon = `
     </path></svg>`;
 
 const clipboardCopiedIcon = `
-    <svg fill="currentColor" class="fill-current text-white h-6 w-6" viewBox="0 0 20 20"><path d="M9 2a1 1 0 000 2h2a1 1 0 100-2H9z"></path>
+    <svg fill="currentColor" class="fill-current text-gray-400 h-6 w-6" viewBox="0 0 20 20"><path d="M9 2a1 1 0 000 2h2a1 1 0 100-2H9z"></path>
         <path fill-rule="evenodd" d="M4 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v11a2 2 0 01-2 2H6a2 2
          0 01-2-2V5zm9.707 5.707a1 1 0 00-1.414-1.414L9 12.586l-1.293-1.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd">
     </path></svg>`;

--- a/resources/sass/_code.scss
+++ b/resources/sass/_code.scss
@@ -18,7 +18,7 @@ pre {
     @apply outline-none;
     @apply text-gray-700;
     &:hover, &:focus, &:active {
-      @apply text-white;
+      @apply text-gray-500;
     }
     svg {
       @apply absolute;

--- a/resources/sass/_code.scss
+++ b/resources/sass/_code.scss
@@ -94,8 +94,7 @@ pre {
   display: block;
   overflow-x: auto;
   padding: 1em;
-  background: #211F2F;
-  color: #ffffff;
+  border: 1px solid #eee;
   font-family: "Fira Mono", monospace;
   font-size: 14px;
   line-height: 40px;

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -3,7 +3,7 @@
 
 // Code syntax highlighting,
 // powered by https://highlightjs.org
-@import '~highlight.js/styles/dracula.css';
+@import '~highlight.js/styles/a11y-light.css';
 
 @import '~@docsearch/css/dist/style.css';
 


### PR DESCRIPTION
Personally I feel that the light theme (which is designed for accessibility) looks better with the rest of the website's design. Although I'm not that bothered either way. 👍🏻

![Current dark highlighting](https://user-images.githubusercontent.com/1899334/97427392-59185180-190c-11eb-9de3-25b46590cd2a.png)

![PR'd light highlighting](https://user-images.githubusercontent.com/1899334/97427417-61708c80-190c-11eb-8b92-801850db4aae.png)
