### PR TITLE
Some DocsController improvements

### DIFF
--- a/app/Http/Controllers/DocsController.php
+++ b/app/Http/Controllers/DocsController.php
@@ -24,25 +24,24 @@ class DocsController extends Controller
      */
     public function __invoke(Documentation $docs, string $page = null)
     {
+        $defaultVersion = config('site.defaultVersion');
+
         if ($page === null) {
             return redirect()->route('docs', [self::DEFAULT_PAGE]);
         }
 
-        if (! $docs->exists(config('site.defaultVersion'), $page) || in_array($page, self::EXCLUDED)) {
+        if ($docs->doesntExists($defaultVersion, $page) || in_array($page, self::EXCLUDED)) {
             abort(404);
         }
 
-        $index = (new Parsedown())->text($docs->getIndex(config('site.defaultVersion')));
+        $parsedown = new Parsedown;
 
-        $file = $docs->get(config('site.defaultVersion'), $page);
-        $contents = YamlFrontMatter::parse($file);
+        $index = $parsedown->text($docs->getIndex($defaultVersion));
+        $contents = YamlFrontMatter::parse($docs->get($defaultVersion, $page));
+
+        $body = $parsedown->text($contents->body());
         $matter = $contents->matter();
-        $markdown = $contents->body();
 
-        $parsedown = new Parsedown();
-        $body = $parsedown->text($markdown);
-
-
-        return view('docs', compact('body', 'matter', 'markdown', 'page', 'index'));
+        return view('docs', compact('body', 'matter', 'page', 'index'));
     }
 }

--- a/app/Http/Controllers/DocsController.php
+++ b/app/Http/Controllers/DocsController.php
@@ -30,7 +30,7 @@ class DocsController extends Controller
             return redirect()->route('docs', [self::DEFAULT_PAGE]);
         }
 
-        if ($docs->doesntExists($defaultVersion, $page) || in_array($page, self::EXCLUDED)) {
+        if (! $docs->exists($defaultVersion, $page) || in_array($page, self::EXCLUDED)) {
             abort(404);
         }
 

--- a/app/Support/Documentation.php
+++ b/app/Support/Documentation.php
@@ -22,6 +22,11 @@ class Documentation
         return $this->filesystem->exists($this->path($version, "{$page}.md"));
     }
 
+    public function doesntExists(string $version, string $page): bool
+    {
+        return ! $this->exists($version, $page);
+    }
+
     public function getIndex(string $version): ?string
     {
         return $this->cache->remember("docs.{$version}.index", 5, function () use ($version) {
@@ -44,5 +49,4 @@ class Documentation
     {
         return resource_path("docs/{$version}/{$file}");
     }
-
 }

--- a/app/Support/Documentation.php
+++ b/app/Support/Documentation.php
@@ -22,11 +22,6 @@ class Documentation
         return $this->filesystem->exists($this->path($version, "{$page}.md"));
     }
 
-    public function doesntExists(string $version, string $page): bool
-    {
-        return ! $this->exists($version, $page);
-    }
-
     public function getIndex(string $version): ?string
     {
         return $this->cache->remember("docs.{$version}.index", 5, function () use ($version) {


### PR DESCRIPTION
Avoid multiple calls to config(‘site.defaultVersion’), single instance of Parsedown, avoid to pass “matter” to views because is not needed