### PR TITLE
Fix build script

### DIFF
--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -9,5 +9,5 @@ composer install
 cp .env.example .env
 php artisan key:generate
 source "$(dirname "$0")/checkout_latest_docs.sh"
-npm install
-npm run prod
+npm ci
+npm run build


### PR DESCRIPTION
- `npm ci` (clean-install) won't change `package-lock.json`
- `npm run build` is the command which is in package.json (`prod` is undefined) 