### PR TITLE
Adapt code block styling to dark mode

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -69,6 +69,7 @@
         @apply flex;
         code {
             @apply flex flex-1;
+            @apply text-gray-200 bg-gray-900 dark:text-gray-200 dark:bg-gray-800;
         }
     }
 


### PR DESCRIPTION
Related Issue: https://github.com/laravel-zero/laravel-zero.com/issues/24

Dark mode

<img width="1000" height="600" alt="Screenshot 2025-11-28 at 9 58 23 PM" src="https://github.com/user-attachments/assets/53a2937b-f536-4634-a6da-f0a009224ed1" />

Light mode

<img width="1000" height="600" alt="Screenshot 2025-11-28 at 9 58 31 PM" src="https://github.com/user-attachments/assets/bf838101-c79a-4fce-a1b3-713e75092aa5" />
